### PR TITLE
Add Claude marketplace plugins (anthropics, trailofbits)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ WORKDIR /workspace
 # Switch to non-root user for remaining setup
 USER vscode
 
-# Install Claude Code natively
-RUN curl -fsSL https://claude.ai/install.sh | bash
+# Install Claude Code natively with marketplace plugins
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+  claude plugin marketplace add anthropics/skills && \
+  claude plugin marketplace add trailofbits/skills
 
 # Install Python 3.13 via uv (fast binary download, not source compilation)
 RUN uv python install 3.13 --default


### PR DESCRIPTION
## Summary
- Install `anthropics/skills` and `trailofbits/skills` marketplace plugins during Claude Code setup in the Dockerfile
- Chains plugin installation with the Claude Code install script to keep the build layer efficient

## Test plan
- [ ] Build the devcontainer and verify Claude Code starts with both plugins available
- [ ] Run `claude plugin list` to confirm plugins are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)