### PR TITLE
Improve README structure and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,15 @@ The container auto-configures `bypassPermissions` mode—Claude runs commands wi
 
 ## Container Details
 
-**Base:** Ubuntu 24.04, Node.js 22, Python 3.13 + uv, zsh with Oh My Zsh. User `vscode` with passwordless sudo, working directory `/workspace`.
+| Component | Details |
+|-----------|---------|
+| Base | Ubuntu 24.04, Node.js 22, Python 3.13 + uv, zsh |
+| User | `vscode` (passwordless sudo), working dir `/workspace` |
+| Tools | `rg`, `fd`, `tmux`, `fzf`, `delta`, `iptables`, `ipset` |
+| Volumes (survive rebuilds) | Command history, Claude config, GitHub CLI auth |
+| Auto-configured | [anthropics](https://github.com/anthropics/claude-code-plugins) + [trailofbits](https://github.com/trailofbits/claude-code-plugins) skills, git-delta |
 
-**Tools:** `rg`, `fd`, `tmux` (200k history), `fzf`, `delta`, `iptables`, `ipset`, `iproute2`, `dnsutils`
-
-**Persisted across rebuilds:** Command history (`/commandhistory`), Claude config (`~/.claude`), GitHub CLI auth (`~/.config/gh`). Host `~/.gitconfig` mounted read-only.
-
-**Auto-configured:** [anthropics](https://github.com/anthropics/claude-code-plugins) and [trailofbits](https://github.com/trailofbits/claude-code-plugins) skills, tmux 200k scrollback, git-delta pager, global gitignore.
-
-**Verify:** `claude --version`, `cat ~/.claude/settings.json`
+Volumes are stored outside the container, so your shell history, Claude settings, and `gh` login persist even after `devc rebuild`. Host `~/.gitconfig` is mounted read-only for git identity.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add "Why Use This?" section explaining the value proposition for security audits
- Document two usage patterns: per-project (isolated) and shared workspace (grouped)
- Add Network Isolation section with a practical iptables example combining Claude + GitHub + package registries
- Simplify Security Model from two subsection lists into compact inline format
- Collapse reference sections into a single `<details>` block

## Changes

The README was expanded to explain *why* and *when* to use this tool. This cleanup pass tightens verbose sections while keeping essential info prominent. VS Code instructions remain explicit with step-by-step guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)