### PR TITLE
Add bubblewrap and socat for Claude Code sandboxing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install additional system packages (base image already includes git, curl, sudo, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  # Sandboxing support for Claude Code
+  bubblewrap \
+  socat \
   # Modern CLI tools
   fzf \
   ripgrep \


### PR DESCRIPTION
## Summary

- Adds `bubblewrap` and `socat` packages required for Claude Code's native sandboxing on Linux

## Why

Claude Code's sandboxing feature provides:
- **Reduced permission prompts** - Commands within sandbox boundaries auto-execute
- **Protection against prompt injection** - Even if Claude is manipulated, it can't access unauthorized files/network
- **Defense against malicious dependencies** - NPM packages or scripts can't escape the sandbox

Without these packages, the `/sandbox` command shows installation instructions instead of enabling sandbox mode.

| Package | Purpose |
|---------|---------|
| `bubblewrap` | Filesystem isolation via Linux namespaces |
| `socat` | Network proxy for domain filtering |

## Reference

https://code.claude.com/docs/en/sandboxing

## Test plan

- [ ] Build the devcontainer
- [ ] Run `/sandbox` in Claude Code and verify it enables without prompting to install dependencies

🤖 Generated with [Claude Code](https://claude.ai/claude-code)