### PR TITLE
Mount .devcontainer/ read-only to prevent container escape on rebuild

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -46,7 +46,8 @@
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
     "source=claude-code-gh-${devcontainerId},target=/home/vscode/.config/gh,type=volume",
-    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly",
+    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,8 @@ extract_mounts_to_file() {
         (startswith("source=claude-code-bashhistory-") | not) and
         (startswith("source=claude-code-config-") | not) and
         (startswith("source=claude-code-gh-") | not) and
-        (startswith("source=${localEnv:HOME}/.gitconfig,") | not)
+        (startswith("source=${localEnv:HOME}/.gitconfig,") | not) and
+        (contains("target=/workspace/.devcontainer,") | not)
       )
     ) | if length > 0 then . else empty end
   ' "$devcontainer_json" 2>/dev/null) || true


### PR DESCRIPTION
A process inside the container could modify .devcontainer/devcontainer.json to inject malicious mounts or initializeCommand entries that execute on the host during the next rebuild. Bind-mounting .devcontainer/ as read-only blocks this privilege escalation vector.