### PR TITLE
Mount .devcontainer/ read-only to prevent container escape on rebuild

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -46,7 +46,8 @@
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
     "source=claude-code-gh-${devcontainerId},target=/home/vscode/.config/gh,type=volume",
-    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly",
+    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
## Summary

- Bind-mounts `.devcontainer/` read-only inside the container to prevent a compromised process from injecting malicious mounts or `initializeCommand` entries into `devcontainer.json` that execute on the host during rebuild
- Filters the new mount out of custom mount preservation in `extract_mounts_to_file()` so it isn't duplicated on template reinstall
- Addresses all review feedback from #12: uses `startswith()` instead of `contains()` for precise jq filtering, adds inline security comment, and documents the SYS_ADMIN guard requirement

Based on #12 with @dguido's review suggestions applied.

## Test plan

- [ ] `devc .` in a fresh directory — verify `.devcontainer/` appears read-only inside the container (`mount | grep devcontainer`)
- [ ] `touch /workspace/.devcontainer/test` from inside container — should fail with read-only filesystem error
- [ ] `devc template .` on an existing setup with custom mounts — verify custom mounts are preserved and the `.devcontainer` mount isn't duplicated
- [ ] `devc rebuild` — verify container comes back with the read-only mount intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)