### PR TITLE
Harden devcontainer: pin digests, guard SYS_ADMIN, fix mount filters

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -51,6 +51,5 @@ _fzf_compgen_dir() {
   fdfind --type d --hidden --follow --exclude .git . "$1"
 }
 
-# Source fzf key bindings and completion
-source ~/.fzf/key-bindings.zsh
-source ~/.fzf/completion.zsh
+# Source fzf shell integration (built-in since fzf 0.48+)
+eval "$(fzf --zsh)"

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -10,8 +10,7 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/tailscale/codespace/tailscale:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "runArgs": [
     "--cap-add=NET_ADMIN",


### PR DESCRIPTION
## Summary

- Pin base image and uv with SHA256 digests for reproducible builds (#15)
- Install fzf v0.67.0 from GitHub releases instead of apt, use built-in shell integration (#14)
- Add `check_no_sys_admin()` guard to block SYS_ADMIN capability that would defeat the read-only .devcontainer mount (#16)
- Fix mount filter to match on target paths instead of source prefixes, fix temp file leak (#17)
- Sort apt packages alphabetically within each section (#18)
- Remove unused Tailscale devcontainer feature (#19)

Closes #14, closes #15, closes #16, closes #17, closes #18, closes #19

## Test plan

- [x] `shellcheck install.sh` — clean
- [x] `python3 -m py_compile post_install.py` — clean
- [x] `jq . devcontainer.json` — valid JSON
- [x] `hadolint Dockerfile` — only pre-existing informational warnings (DL3008, DL3059)
- [x] SYS_ADMIN guard: rejects SYS_ADMIN, allows NET_ADMIN, handles missing file
- [x] Mount filter: filters all default mounts, preserves custom mounts, handles empty
- [x] `docker build` succeeds
- [x] `fzf --version` → 0.67.0
- [x] `fzf --zsh` integration works
- [x] `uv --version` → 0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)