### PR TITLE
Minor cleanups: UTC default, shellcheck, comment clarity

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Zsh configuration for Claude Code devcontainer
 
 # Add Claude Code to PATH

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -4,7 +4,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "TZ": "${localEnv:TZ:America/New_York}",
+      "TZ": "${localEnv:TZ:UTC}",
       "GIT_DELTA_VERSION": "0.18.2",
       "ZSH_IN_DOCKER_VERSION": "1.2.1"
     }

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ extract_mounts_to_file() {
 
   temp_file=$(mktemp)
 
-  # Filter out default mounts (template mounts we don't want to preserve)
+  # Filter out default mounts by target path (immune to project name changes)
   local custom_mounts
   custom_mounts=$(jq -c '
     .mounts // [] | map(
@@ -248,8 +248,9 @@ cmd_down() {
   log_info "Stopping devcontainer..."
 
   # Get container ID and stop it
+  local label="devcontainer.local_folder=$workspace_folder"
   local container_id
-  container_id=$(docker ps -q --filter "label=devcontainer.local_folder=$workspace_folder" 2>/dev/null || true)
+  container_id=$(docker ps -q --filter "label=$label" 2>/dev/null || true)
 
   if [[ -n "$container_id" ]]; then
     docker stop "$container_id"


### PR DESCRIPTION
## Summary

- Default timezone to UTC instead of America/New_York
- Add `# shellcheck shell=bash` directive to `.zshrc` (matches trailofbits/skills devcontainer-setup)
- Extract docker filter label into local variable in `cmd_down`
- Clarify mount filter comment to explain why target paths are used

## Test plan

- [ ] Verify container starts with UTC timezone when host `TZ` is unset
- [ ] Verify host `TZ` still overrides the default
- [ ] Run `shellcheck .zshrc` passes with the directive
- [ ] `devc down` still stops containers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)