### PR TITLE
Fix bind mount failure when ~/.gitconfig does not exist

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -63,6 +63,7 @@
     "PYTHONDONTWRITEBYTECODE": "1",
     "PIP_DISABLE_PIP_VERSION_CHECK": "1"
   },
+  "initializeCommand": "test -f \"$HOME/.gitconfig\" || touch \"$HOME/.gitconfig\"",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "uv run --no-project /opt/post_install.py"


### PR DESCRIPTION
## Summary

- Docker bind mount on `devcontainer.json:48` fails when `~/.gitconfig` doesn't exist on the host (fresh machines, XDG-based git config, system-only config)
- Add `initializeCommand` to create an empty `~/.gitconfig` before container start — an empty gitconfig is valid and has no side effects

## Test plan

- [ ] Verify container starts with existing `~/.gitconfig` (no behavior change)
- [ ] `mv ~/.gitconfig ~/.gitconfig.bak`, run `devc rebuild`, confirm container starts successfully
- [ ] Confirm git identity is correct inside the container after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)