### PR TITLE
Fix SSH commit signing when host uses 1Password

### DIFF
--- a/post_install.py
+++ b/post_install.py
@@ -199,6 +199,9 @@ node_modules/
 
 [diff]
     colorMoved = default
+
+[gpg "ssh"]
+    program = /usr/bin/ssh-keygen
 """
     local_gitconfig.write_text(local_config, encoding="utf-8")
     print(f"[post_install] Local git config created: {local_gitconfig}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Override `gpg.ssh.program` in the container's `.gitconfig.local` to use `/usr/bin/ssh-keygen` instead of whatever the host has configured
- Fixes commit signing failure when the host sets this to 1Password's `op-ssh-sign` binary, which doesn't exist inside the container
- Works because DevContainers automatically forward `SSH_AUTH_SOCK`, so the host's SSH agent (including 1Password's) is already accessible — only the signing program path needs to differ

## Test plan

- [ ] Build devcontainer with a host `.gitconfig` that sets `gpg.ssh.program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign`
- [ ] Verify `git commit -S` succeeds inside the container using the forwarded SSH agent
- [ ] Verify the override appears after the `[include]` directive in `~/.gitconfig.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)