### PR TITLE
Add `cp` command to copy files from container to host

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ Commands:
     exec <cmd>          Execute a command in the running container
     upgrade             Upgrade Claude Code to latest version
     mount <host> <cont> Add a mount to the devcontainer (recreates container)
+    cp <cont> <host>    Copy files/directories from container to host
     help                Show this help message
 
 Examples:
@@ -49,6 +50,7 @@ Examples:
     devc exec ls -la            # Run command in container
     devc upgrade                # Upgrade Claude Code to latest
     devc mount ~/data /data     # Add mount to container
+    devc cp /some/file ./out    # Copy a path from container to host
 EOF
 }
 
@@ -328,6 +330,33 @@ cmd_mount() {
   log_success "Mount added: $host_path → $container_path"
 }
 
+cmd_cp() {
+  local container_path="${1:-}"
+  local host_path="${2:-}"
+
+  if [[ -z "$container_path" ]] || [[ -z "$host_path" ]]; then
+    log_error "Usage: devc cp <container_path> <host_path>"
+    exit 1
+  fi
+
+  local workspace_folder
+  workspace_folder="$(get_workspace_folder)"
+
+  # Find the running container
+  local label="devcontainer.local_folder=$workspace_folder"
+  local container_id
+  container_id=$(docker ps -q --filter "label=$label" 2>/dev/null || true)
+
+  if [[ -z "$container_id" ]]; then
+    log_error "No running devcontainer found for $workspace_folder"
+    exit 1
+  fi
+
+  log_info "Copying $container_path → $host_path"
+  docker cp "$container_id:$container_path" "$host_path"
+  log_success "Copied $container_path → $host_path"
+}
+
 cmd_self_install() {
   local install_dir="$HOME/.local/bin"
   local install_path="$install_dir/devc"
@@ -414,6 +443,9 @@ main() {
     ;;
   mount)
     cmd_mount "$@"
+    ;;
+  cp)
+    cmd_cp "$@"
     ;;
   self-install)
     cmd_self_install


### PR DESCRIPTION
Enables ad-hoc file extraction from a running devcontainer using `docker cp`, without requiring a mount or container rebuild.

Usage: `devc cp <container_path> <host_path>`