### PR TITLE
[tech] Microsoft changed the tag name for ubuntu devcontainers after …

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -10,7 +10,6 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "runArgs": [


### PR DESCRIPTION
…2.0.5, so fix that and point to 2.1.7-ubuntu24.04. Also update uv to 0.10.9 and fzf to 0.70.0.

Here's the commit where msft broke it: https://github.com/devcontainers/images/commit/92a034a8df06e7fce2fd3f101a52948cad698c72 