### PR TITLE
feat: add Renovate config to keep Dockerfile updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install git-delta
+# renovate: datasource=github-releases depName=dandavison/delta
 ARG GIT_DELTA_VERSION=0.18.2
 RUN ARCH=$(dpkg --print-architecture) && \
   curl -fsSL "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" -o /tmp/git-delta.deb && \
@@ -43,6 +44,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 COPY --from=uv /uv /usr/local/bin/uv
 
 # Install fzf from GitHub releases (newer than apt, includes built-in shell integration)
+# renovate: datasource=github-releases depName=junegunn/fzf
 ARG FZF_VERSION=0.70.0
 RUN ARCH=$(dpkg --print-architecture) && \
   case "${ARCH}" in \
@@ -94,6 +96,7 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$FNM_D
   fnm default ${NODE_VERSION}
 
 # Install Oh My Zsh
+# renovate: datasource=github-releases depName=deluan/zsh-in-docker
 ARG ZSH_IN_DOCKER_VERSION=1.2.1
 RUN sh -c "$(curl -fsSL https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
   -p git \

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on monday"],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Group all updates into a single PR",
+      "matchPackageNames": ["*"],
+      "groupName": "all dependencies",
+      "groupSlug": "all"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update ARG versions in Dockerfile from GitHub releases",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)\\n(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\n"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `renovate.json` with a custom regex manager to track ARG-based versions (git-delta, fzf, zsh-in-docker) from GitHub releases
- Add `# renovate:` comment directives to the Dockerfile for each ARG version
- Docker base images (`uv`, `devcontainers/base`) are tracked automatically by Renovate's built-in dockerfile manager
- Weekly schedule (Monday before 9am), 7-day release cooldown, all updates grouped into a single PR

## Test plan
- [x] `renovate-config-validator` passes cleanly
- [x] `renovate --dry-run --platform=local` detects all 5 dependencies (2 Docker images + 3 GitHub releases)
- [x] Downgraded fzf to 0.60.0 locally and confirmed Renovate proposes updating to 0.70.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)