### PR TITLE
Address Potential Container Escape via git

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -46,7 +46,9 @@
     "source=devc-${localWorkspaceFolderBasename}-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
     "source=devc-${localWorkspaceFolderBasename}-gh-${devcontainerId},target=/home/vscode/.config/gh,type=volume",
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly",
-    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly"
+    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly",
+    "source=${localWorkspaceFolder}/.git/config,target=/workspace/.git/config,type=bind,readonly",
+    "source=${localWorkspaceFolder}/.git/hooks,target=/workspace/.git/hooks,type=bind,readonly"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
This patch prevents claude from manipulating `.git/hooks` or `.git/config` which could result in unintended code execution outside the devcontainer.

As an example, ask claude to create a git hook to print "Hello World" on commit or push. Outside of the devcontainer, the git status is clean, but running `git commit` or `git push` will result in printing "Hello World".

Credit for this discovery to @tillberg.