### PR TITLE
Make install.sh shebang more generic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Claude Code Devcontainer CLI Helper


### PR DESCRIPTION
#### Problem

The install script doesn't work on setups which put `bash` in a different place than `/bin`. For example, nixos doesn't put its bins there.

#### Summary of changes

Use the more generic shebang of `#!/usr/bin/env bash` to allow the system to find it instead.